### PR TITLE
Reorganize distributable sources structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "t8on",
   "version": "0.2.0-alpha.1",
   "description": "Set up, format and translate phrases easily",
-  "main": "dist/t8on.js",
-  "module": "dist/t8on.es.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/es/index.js",
   "typescript": {
     "definition": "dist/t8on.d.ts"
   },
   "scripts": {
-    "build": "mkdir dist && run-p build:cjs build:es build:typedefs build:umd",
-    "build:cjs": "cross-env BABEL_ENV=cjs babel src -o dist/t8on.js",
-    "build:es": "babel src -o dist/t8on.es.js",
+    "build": "mkdir -p dist && run-p build:cjs build:es build:typedefs build:umd",
+    "build:cjs": "cross-env BABEL_ENV=cjs babel src -d dist/cjs",
+    "build:es": "babel src -d dist/es",
     "build:typedefs": "node ./res/copy-typedefs.js",
     "build:umd": "webpack --config res/umd.config.js",
     "clean": "rm -rf .nyc_output coverage dist",

--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,5 @@
-function merge(object, source) {
-  if (typeof source === 'undefined' || source === null) {
-    return object;
-  }
-
-  // eslint-disable-next-line no-var
-  for (var v0, v1, k, keys = Object.keys(source), l = keys.length, i = 0; i < l; ++i) {
-    k = keys[i], v1 = source[k];
-    if (typeof v1 !== 'undefined') {
-      v0 = object[k];
-      if (
-        typeof v1 === 'object' && v1 !== null &&
-        typeof v0 === 'object' && v0 !== null
-      ) {
-        merge(v0, v1);
-      } else {
-        object[k] = v1;
-      }
-    }
-  }
-
-  return object;
-}
+import deprecate from './util/deprecate';
+import merge from './util/merge';
 
 export function Translation() {
   const dictionary = {};
@@ -87,38 +66,26 @@ export function Translation() {
     this.format(phrase, this.currentLocale || '', ...args);
 }
 
-const deprecated = (f) => {
-  const g = function () {
-    if (!this.calledBefore) {
-      this.calledBefore = true;
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Deprecation warning: usage of t8on singleton\'s properties ' +
-        'and methods imported manually is considered deprecated. ' +
-        'All *named* exports except Translation will be removed ' +
-        'in upcoming major release. Please export the singleton and call ' +
-        'its methods directly, such as t.translate()'
-      );
-    }
-    return f.apply(null, arguments);
-  };
-
-  return g;
-};
+const EXPORTED_SINGLETON_METHODS_DEPRECATION_NOTICE =
+  'Deprecation warning: usage of t8on singleton\'s properties ' +
+  'and methods imported manually is considered deprecated. ' +
+  'All *named* exports except Translation will be removed ' +
+  'in upcoming major release. Please export the singleton and call ' +
+  'its methods directly, such as t.translate()';
 
 const t = new Translation();
 
-export const format = deprecated(t.format);
-export const formatTo = deprecated(t.formatTo);
-export const formatCurrent = deprecated(t.formatCurrent);
+export const format = deprecate(t.format, EXPORTED_SINGLETON_METHODS_DEPRECATION_NOTICE);
+export const formatTo = deprecate(t.formatTo, EXPORTED_SINGLETON_METHODS_DEPRECATION_NOTICE);
+export const formatCurrent = deprecate(t.formatCurrent, EXPORTED_SINGLETON_METHODS_DEPRECATION_NOTICE);
 
-export const translate = deprecated(t.translate);
-export const translateTo = deprecated(t.translateTo);
-export const translateCurrent = deprecated(t.translateCurrent);
+export const translate = deprecate(t.translate, EXPORTED_SINGLETON_METHODS_DEPRECATION_NOTICE);
+export const translateTo = deprecate(t.translateTo, EXPORTED_SINGLETON_METHODS_DEPRECATION_NOTICE);
+export const translateCurrent = deprecate(t.translateCurrent, EXPORTED_SINGLETON_METHODS_DEPRECATION_NOTICE);
 
-export const load = deprecated(t.load);
-export const loadRoot = deprecated(t.loadRoot);
-export const setLocale = deprecated(t.setLocale);
+export const load = deprecate(t.load, EXPORTED_SINGLETON_METHODS_DEPRECATION_NOTICE);
+export const loadRoot = deprecate(t.loadRoot, EXPORTED_SINGLETON_METHODS_DEPRECATION_NOTICE);
+export const setLocale = deprecate(t.setLocale, EXPORTED_SINGLETON_METHODS_DEPRECATION_NOTICE);
 
 export const currentLocale = t.currentLocale;
 export const fallbackLocale = t.fallbackLocale;

--- a/src/index.js
+++ b/src/index.js
@@ -1,70 +1,7 @@
 import deprecate from './util/deprecate';
-import merge from './util/merge';
+import Translation from './translation';
 
-export function Translation() {
-  const dictionary = {};
-
-  this.currentLocale = null;
-  this.fallbackLocale = null;
-
-  this.dictionary = () => dictionary;
-
-  this.load = (locale, pairs) => {
-    if (!(locale in dictionary)) {
-      dictionary[locale] = {};
-    }
-    merge(dictionary[locale], pairs);
-    return this;
-  };
-
-  this.loadRoot = (root) => {
-    merge(dictionary, root);
-    return this;
-  };
-
-  this.setLocale = (locale, dic) => {
-    dictionary[locale] = dic;
-    return this;
-  };
-
-  this.translate = (phrase, locale) => {
-    if (!(locale in dictionary) || !(phrase in dictionary[locale])) {
-      if (!this.fallbackLocale || locale === this.fallbackLocale) {
-        return '';
-      }
-
-      return this.translate(phrase, this.fallbackLocale);
-    }
-
-    return dictionary[locale][phrase];
-  };
-
-  this.translateTo = locale => phrase =>
-    this.translate(phrase, locale);
-
-  this.translateCurrent = phrase =>
-    this.translate(phrase, this.currentLocale || '');
-
-  this.format = (phrase, locale, ...args) => {
-    if (!(locale in dictionary) || !(phrase in dictionary[locale])) {
-      if (!this.fallbackLocale || locale === this.fallbackLocale) {
-        return '';
-      }
-
-      return this.format(phrase, this.fallbackLocale, ...args);
-    }
-
-    return dictionary[locale][phrase].replace(/%(\S)/g, (_, i) => {
-      return args[i];
-    });
-  };
-
-  this.formatTo = locale => (phrase, ...args) =>
-    this.format(phrase, locale, ...args);
-
-  this.formatCurrent = (phrase, ...args) =>
-    this.format(phrase, this.currentLocale || '', ...args);
-}
+export { Translation };
 
 const EXPORTED_SINGLETON_METHODS_DEPRECATION_NOTICE =
   'Deprecation warning: usage of t8on singleton\'s properties ' +

--- a/src/translation.js
+++ b/src/translation.js
@@ -1,0 +1,66 @@
+import merge from './util/merge';
+
+export default function Translation() {
+  const dictionary = {};
+
+  this.currentLocale = null;
+  this.fallbackLocale = null;
+
+  this.dictionary = () => dictionary;
+
+  this.load = (locale, pairs) => {
+    if (!(locale in dictionary)) {
+      dictionary[locale] = {};
+    }
+    merge(dictionary[locale], pairs);
+    return this;
+  };
+
+  this.loadRoot = (root) => {
+    merge(dictionary, root);
+    return this;
+  };
+
+  this.setLocale = (locale, dic) => {
+    dictionary[locale] = dic;
+    return this;
+  };
+
+  this.translate = (phrase, locale) => {
+    if (!(locale in dictionary) || !(phrase in dictionary[locale])) {
+      if (!this.fallbackLocale || locale === this.fallbackLocale) {
+        return '';
+      }
+
+      return this.translate(phrase, this.fallbackLocale);
+    }
+
+    return dictionary[locale][phrase];
+  };
+
+  this.translateTo = locale => phrase =>
+    this.translate(phrase, locale);
+
+  this.translateCurrent = phrase =>
+    this.translate(phrase, this.currentLocale || '');
+
+  this.format = (phrase, locale, ...args) => {
+    if (!(locale in dictionary) || !(phrase in dictionary[locale])) {
+      if (!this.fallbackLocale || locale === this.fallbackLocale) {
+        return '';
+      }
+
+      return this.format(phrase, this.fallbackLocale, ...args);
+    }
+
+    return dictionary[locale][phrase].replace(/%(\S)/g, (_, i) => {
+      return args[i];
+    });
+  };
+
+  this.formatTo = locale => (phrase, ...args) =>
+    this.format(phrase, locale, ...args);
+
+  this.formatCurrent = (phrase, ...args) =>
+    this.format(phrase, this.currentLocale || '', ...args);
+}

--- a/src/util/deprecate.js
+++ b/src/util/deprecate.js
@@ -1,0 +1,12 @@
+module.exports = (f, message) => {
+  const g = function () {
+    if (!this.calledBefore) {
+      this.calledBefore = true;
+      // eslint-disable-next-line no-console
+      console.warn(message);
+    }
+    return f.apply(null, arguments);
+  };
+
+  return g;
+};

--- a/src/util/merge.js
+++ b/src/util/merge.js
@@ -1,0 +1,23 @@
+module.exports = function merge(object, source) {
+  if (typeof source === 'undefined' || source === null) {
+    return object;
+  }
+
+  // eslint-disable-next-line no-var
+  for (var v0, v1, k, keys = Object.keys(source), l = keys.length, i = 0; i < l; ++i) {
+    k = keys[i], v1 = source[k];
+    if (typeof v1 !== 'undefined') {
+      v0 = object[k];
+      if (
+        typeof v1 === 'object' && v1 !== null &&
+        typeof v0 === 'object' && v0 !== null
+      ) {
+        merge(v0, v1);
+      } else {
+        object[k] = v1;
+      }
+    }
+  }
+
+  return object;
+};


### PR DESCRIPTION
Preserve sources original structure in CommonJS and ES builds.

Add a way to ignore singleton instantiation if only `Translation` class is used with
```javascript
import Translation from 't8on/translation';
```